### PR TITLE
Add all/cookies to spec

### DIFF
--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,0 +1,7 @@
+{
+    "src_file": "spec.bs",
+    "type": "bikeshed",
+    "params": {
+        "force": 1
+    }
+}

--- a/spec.bs
+++ b/spec.bs
@@ -65,7 +65,7 @@ This specification defines a method to request access to [=unpartitioned data=] 
 Alex visits `https://social.example/`. The page sets a some local storage. This local storage has been set in a [=first-party-site context=].
 
 ```javascript
-document.localStorage.setItem("userid", "1234");
+window.localStorage.setItem("userid", "1234");
 ```
 
 Later on, Alex visits `https://video.example/`, which has an <{iframe}> on it which loads `https://social.example/heart-button`. In this case, the `social.example` {{Document}} |doc| is in a [=third party context=], and the local storage set previously might or might not be visible depending on User Agent storage access policies.

--- a/spec.bs
+++ b/spec.bs
@@ -132,14 +132,6 @@ Modify {{Document/requestStorageAccess()}} at step 14.1.1.1.1 to read:
 
 1. If |requestUnpartitionedCookieAccess| is `true`, then set <var ignore='monkeypatch'>global</var>'s [=environment/has storage access=] to true.
 
-Modify {{Document/requestStorageAccess()}} at step 14.3 to read:
-
-3. If |explicitSetting| is "`disallow`" and |requestUnpartitionedCookieAccess| is `true`:
-
-Modify {{Document/requestStorageAccess()}} at step 14.5 to read:
-
-5. [=Assert=]: |explicitSetting| is "`none`" or |requestUnpartitionedCookieAccess| is `false`.
-
 <h3 id="storage">Changes to various client-side storage mechanisms</h3>
 
 <h4 id="dom-storage">DOM Storage</h4>

--- a/spec.bs
+++ b/spec.bs
@@ -20,42 +20,13 @@ spec:html; type:dfn; for:site; text:same site
 </pre>
 
 <pre class="anchors">
-urlPrefix: https://fetch.spec.whatwg.org/; spec: Fetch
-    text: http-network-or-cache fetch; url: #concept-http-network-or-cache-fetch; type: dfn
-spec: RFC6265; urlPrefix: https://tools.ietf.org/html/rfc6265
-    type: dfn
-        text: cookie store; url: section-5.3
-spec: RFC6265bis; urlPrefix: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-11
-    type: dfn
-        text: site for cookies; url: section-5.2.1
-urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#; spec: webdriver
-    type: dfn
-        text: current browsing context; url: dfn-current-browsing-context
-        text: WebDriver error; url: dfn-error
-        text: WebDriver error code; url: dfn-error-code
-        text: extension command; url: dfn-extension-commands
-        text: extension command URI template; url: dfn-extension-command-uri-template
-        text: getting a property; url: dfn-getting-properties
-        text: invalid argument; url: dfn-invalid-argument
-        text: local end; url: dfn-local-end
-        text: remote end steps; url: dfn-remote-end-steps
-        text: unknown error; url: dfn-unknown-error
-        text: unsupported operation; url: dfn-unsupported-operation
-        text: session; url: dfn-session
-        text: success; url: dfn-success
-
-spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
-    type: dfn
-        text: source snapshot params; url: browsing-the-web.html#source-snapshot-params
-        text: snapshotting source snapshot params; url: browsing-the-web.html#snapshotting-source-snapshot-params
-        text: create navigation params by fetching; url: browsing-the-web.html#create-navigation-params-by-fetching
-        text: set up a window environment settings object; url: nav-history-apis.html#set-up-a-window-environment-settings-object
-        text: environment
-
 spec: storage-access; urlPrefix: https://privacycg.github.io/storage-access/
     type: dfn
         for: environment
             text: has storage access; url: #environment-has-storage-access
+        text: unpartitioned data; url: #unpartitioned-data
+        text: first-party-site context; url: #first-party-site-context
+        text: third party context; url: #third-party-context
 </pre>
 
 <pre class=biblio>
@@ -93,22 +64,20 @@ This specification defines a method to request access to [=unpartitioned data=] 
 
 Alex visits `https://social.example/`. The page sets a some local storage. This local storage has been set in a [=first-party-site context=].
 
+```javascript
+document.localStorage.setItem("userid", "1234");
+```
+
 Later on, Alex visits `https://video.example/`, which has an <{iframe}> on it which loads `https://social.example/heart-button`. In this case, the `social.example` {{Document}} |doc| is in a [=third party context=], and the local storage set previously might or might not be visible depending on User Agent storage access policies.
 
 Script in the <{iframe}> can call |doc|`.`{{Document/requestStorageAccess(types)}} to request access.
 
-```
+```javascript
 let handle = await document.requestStorageAccess({localStorage: true});
-handle.localStorage.setItem("userid", "1234");
+let userid = handle.localStorage.getItem("userid");
 ```
 
 </div>
-
-<dfn>Unpartitioned data</dfn> is client-side storage that would be available to a [=site=] were it loaded in a [=first-party-site context=].
-
-A {{Document}} is in a <dfn>first-party-site context</dfn> if it is the [=active document=] of a [=top-level browsing context=]. Otherwise, it is in a [=first-party-site context=] if it is an [=active document=] and the [=environment settings object/origin=] and [=top-level origin=] of its [=relevant settings object=] are [=same site=] with one another.
-
-A {{Document}} is in a <dfn>third party context</dfn> if it is not in a [=first-party-site context=].
 
 <h3 id="document-changes">Changes to {{Document}}</h3>
 

--- a/spec.bs
+++ b/spec.bs
@@ -98,7 +98,7 @@ partial interface Document {
 
 When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>hasUnpartitionedCookieAccess()</code></dfn> method must run these steps:
 
-1. Return the invocation of {{Document/hasStorageAccess()}}.
+1. Return the invocation of {{Document/hasStorageAccess()}} on |doc|.
 
 Note:
 Now that {{Document/requestStorageAccess(types)}} <span class=allow-2119>can</span> be used to request [=unpartitioned data=] with or without specifically requesting cookies, it <span class=allow-2119>must</span> be made clear that {{Document/hasStorageAccess()}} only returns true if [=first-party-site context=] cookies are accessable to the current document.

--- a/spec.bs
+++ b/spec.bs
@@ -113,7 +113,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
     1. Return |p|.
 1. Let |requestUnpartitionedCookieAccess| be `true` if |types|.{{StorageAccessTypes/all}} is `true` or |types|.{{StorageAccessTypes/cookies}} is `true`, and `false` otherwise.
 1. Run the following steps [=in parallel=]:
-    1. Let |accessPromise| be the result of invoking {{Document/requestStorageAccess()}} with |requestUnpartitionedCookieAccess|.
+    1. Let |accessPromise| be the result of running [=request storage access=] with |doc| with |requestUnpartitionedCookieAccess|.
     1. If |accessPromise| [=/rejects=] with `reason` |r|:
         1. [=/Reject=] |p| with |r|.
     1. Else:

--- a/spec.bs
+++ b/spec.bs
@@ -98,7 +98,12 @@ partial interface Document {
 
 When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>hasUnpartitionedCookieAccess()</code></dfn> method must run these steps:
 
-1. Invoke {{Document/hasStorageAccess()}}
+1. Return the result from a call to {{Document/hasStorageAccess()}}.
+
+Note:
+Now that {{Document/requestStorageAccess(types)}} <span class=allow-2119>can</span> be used to request [=unpartitioned data=] with or without specifically requesting cookies, it <span class=allow-2119>must</span> be made clear that {{Document/hasStorageAccess()}} only returns true if [=first-party-site context=] cookies are accessable to the current document.
+As a function name, {{Document/hasUnpartitionedCookieAccess()}} more clearly communicates this.
+For now {{Document/hasStorageAccess()}} is not considered deprecated, but that <span class=allow-2119>may</span> be worth taking up in future.
 
 When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>requestStorageAccess(types)</code></dfn> method must run these steps:
 
@@ -110,11 +115,6 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
     1. [=/Resolve=] |p| with |handle|.
 1. Return |p|.
 
-<h3 id="has-storage-access-changes">Changes to {{Document/hasStorageAccess()}}</h3>
-
-Now that {{Document/requestStorageAccess(types)}} can be used to request [=unpartitioned data=] with or without specifically requesting cookies, it must be made clear that {{Document/hasStorageAccess()}} only returns true if [=first-party-site context=] cookies are accessable to the current document.
-As a function name, {{Document/hasUnpartitionedCookieAccess()}} more clearly communicates this.
-For now {{Document/hasStorageAccess()}} is not considered deprecated, but that may be worth taking up in future.
 
 <h3 id="request-storage-access-changes">Changes to {{Document/requestStorageAccess()}}</h3>
 

--- a/spec.bs
+++ b/spec.bs
@@ -108,7 +108,9 @@ For now {{Document/hasStorageAccess()}} is not considered deprecated, but that <
 When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>requestStorageAccess(types)</code></dfn> method must run these steps:
 
 1. Let |p| be [=a new promise=].
-1. If |types|.{{StorageAccessTypes/all}} is `false` and |types|.{{StorageAccessTypes/cookies}} is `false`, then [=/reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
+1. If |types|.{{StorageAccessTypes/all}} is `false` and |types|.{{StorageAccessTypes/cookies}} is `false`:
+    1. [=/Reject=] |p| with an "{{InvalidStateError}}" {{DOMException}}.
+    1. Return |p|.
 1. Let |requestUnpartitionedCookieAccess| be `true` if |types|.{{StorageAccessTypes/all}} is `true` or |types|.{{StorageAccessTypes/cookies}} is `true`, and `false` otherwise.
 1. Run the following steps [=in parallel=]:
     1. Let |accessPromise| be the result of invoking {{Document/requestStorageAccess()}} with |requestUnpartitionedCookieAccess|.

--- a/spec.bs
+++ b/spec.bs
@@ -124,7 +124,8 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 
 <h3 id="request-storage-access-changes">Changes to {{Document/requestStorageAccess()}}</h3>
 
-Modify {{Document/requestStorageAccess()}} to invoke [=request storage access=] with |requestUnpartitionedCookieAccess| being `true`.
+Redefine {{Document/requestStorageAccess()}} to:
+1. Return the result of running [=request storage access=] with |doc| and |requestUnpartitionedCookieAccess| being `true`.
 
 Redefine the steps of {{Document/requestStorageAccess()}} to instead be the steps of <dfn export>request storage access</dfn> which takes a `boolean` argument |requestUnpartitionedCookieAccess|.
 

--- a/spec.bs
+++ b/spec.bs
@@ -98,7 +98,7 @@ partial interface Document {
 
 When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>hasUnpartitionedCookieAccess()</code></dfn> method must run these steps:
 
-1. Return the result from a call to {{Document/hasStorageAccess()}}.
+1. Return the invocation of {{Document/hasStorageAccess()}}.
 
 Note:
 Now that {{Document/requestStorageAccess(types)}} <span class=allow-2119>can</span> be used to request [=unpartitioned data=] with or without specifically requesting cookies, it <span class=allow-2119>must</span> be made clear that {{Document/hasStorageAccess()}} only returns true if [=first-party-site context=] cookies are accessable to the current document.
@@ -110,9 +110,13 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. Let |p| be [=a new promise=].
 1. If |types|.{{StorageAccessTypes/all}} is `false` and |types|.{{StorageAccessTypes/cookies}} is `false`, then [=/reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. Let |requestUnpartitionedCookieAccess| be `true` if |types|.{{StorageAccessTypes/all}} is `true` or |types|.{{StorageAccessTypes/cookies}} is `true`, and `false` otherwise.
-1. [=React=] |p| to the invocation of {{Document/requestStorageAccess()}} given |requestUnpartitionedCookieAccess| and invoke the following steps if the promise is fulfilled (if the promise is rejected then apply that same rejection to |p|):
-    1. Let |handle| be a new object of type {{StorageAccessHandle}} with |types|.
-    1. [=/Resolve=] |p| with |handle|.
+1. Run the following steps [=in parallel=]:
+    1. Let |accessPromise| be the result of invoking {{Document/requestStorageAccess()}} with |requestUnpartitionedCookieAccess|.
+    1. If |accessPromise| [=/rejects=] with `reason` |r|:
+        1. [=/Reject=] |p| with |r|.
+    1. Else:
+        1. Let |handle| be a new object of type {{StorageAccessHandle}} with |types|.
+        1. [=/Resolve=] |p| with |handle|.
 1. Return |p|.
 
 

--- a/spec.bs
+++ b/spec.bs
@@ -118,7 +118,9 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 
 <h3 id="request-storage-access-changes">Changes to {{Document/requestStorageAccess()}}</h3>
 
-Modify {{Document/requestStorageAccess()}} to take a `boolean` |requestUnpartitionedCookieAccess| as a non-web-exposed argument which defaults to true.
+Modify {{Document/requestStorageAccess()}} to invoke [=request storage access=] with |requestUnpartitionedCookieAccess| being `true`.
+
+Redefine the steps of {{Document/requestStorageAccess()}} to instead be the steps of <dfn export>request storage access</dfn> which takes a `boolean` argument |requestUnpartitionedCookieAccess|.
 
 Modify {{Document/requestStorageAccess()}} at step 14.1.1.1.1 to read:
 

--- a/spec.bs
+++ b/spec.bs
@@ -103,8 +103,8 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>requestStorageAccess(types)</code></dfn> method must run these steps:
 
 1. Let |p| be [=a new promise=].
-1. If |types|'s member |all| is `false` and |types|'s member |cookies| is `false`, then [=/reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
-1. Let |requestUnpartitionedCookieAccess| be `true` if |types|'s member |all| is `true` or |types|'s member |cookies| is `true`, and `false` otherwise.
+1. If |types|.{{StorageAccessTypes/all}} is `false` and |types|.{{StorageAccessTypes/cookies}} is `false`, then [=/reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
+1. Let |requestUnpartitionedCookieAccess| be `true` if |types|.{{StorageAccessTypes/all}} is `true` or |types|.{{StorageAccessTypes/cookies}} is `true`, and `false` otherwise.
 1. [=React=] |p| to the invocation of {{Document/requestStorageAccess()}} given |requestUnpartitionedCookieAccess| and invoke the following steps if the promise is fulfilled (if the promise is rejected then apply that same rejection to |p|):
     1. Let |handle| be a new object of type {{StorageAccessHandle}} with |types|.
     1. [=/Resolve=] |p| with |handle|.

--- a/spec.bs
+++ b/spec.bs
@@ -104,7 +104,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 
 1. Let |p| be [=a new promise=].
 1. If |types|'s member |all| is `false` and |types|'s member |cookies| is `false`, then [=/reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
-1. Let |requestUnpartitionedCookieAccess| be true if |types|'s member |all| or |types|'s member |cookies| is `true` and `false` otherwise.
+1. Let |requestUnpartitionedCookieAccess| be `true` if |types|'s member |all| is `true` or |types|'s member |cookies| is `true`, and `false` otherwise.
 1. [=React=] |p| to the invocation of {{Document/requestStorageAccess()}} given |requestUnpartitionedCookieAccess| and invoke the following steps if the promise is fufilled (if the promise is rejected then apply that same rejection to |p|):
     1. Let |handle| be a new object of type {{StorageAccessHandle}} with |types|.
     1. [=/Resolve=] |p| with |handle|.

--- a/spec.bs
+++ b/spec.bs
@@ -105,7 +105,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. Let |p| be [=a new promise=].
 1. If |types|'s member |all| is `false` and |types|'s member |cookies| is `false`, then [=/reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. Let |requestUnpartitionedCookieAccess| be `true` if |types|'s member |all| is `true` or |types|'s member |cookies| is `true`, and `false` otherwise.
-1. [=React=] |p| to the invocation of {{Document/requestStorageAccess()}} given |requestUnpartitionedCookieAccess| and invoke the following steps if the promise is fufilled (if the promise is rejected then apply that same rejection to |p|):
+1. [=React=] |p| to the invocation of {{Document/requestStorageAccess()}} given |requestUnpartitionedCookieAccess| and invoke the following steps if the promise is fulfilled (if the promise is rejected then apply that same rejection to |p|):
     1. Let |handle| be a new object of type {{StorageAccessHandle}} with |types|.
     1. [=/Resolve=] |p| with |handle|.
 1. Return |p|.

--- a/spec.bs
+++ b/spec.bs
@@ -15,6 +15,49 @@ Markup Shorthands: markdown yes, css no
 Complain About: accidental-2119 true
 </pre>
 
+<pre class=link-defaults>
+spec:html; type:dfn; for:site; text:same site
+</pre>
+
+<pre class="anchors">
+urlPrefix: https://fetch.spec.whatwg.org/; spec: Fetch
+    text: http-network-or-cache fetch; url: #concept-http-network-or-cache-fetch; type: dfn
+spec: RFC6265; urlPrefix: https://tools.ietf.org/html/rfc6265
+    type: dfn
+        text: cookie store; url: section-5.3
+spec: RFC6265bis; urlPrefix: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-11
+    type: dfn
+        text: site for cookies; url: section-5.2.1
+urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#; spec: webdriver
+    type: dfn
+        text: current browsing context; url: dfn-current-browsing-context
+        text: WebDriver error; url: dfn-error
+        text: WebDriver error code; url: dfn-error-code
+        text: extension command; url: dfn-extension-commands
+        text: extension command URI template; url: dfn-extension-command-uri-template
+        text: getting a property; url: dfn-getting-properties
+        text: invalid argument; url: dfn-invalid-argument
+        text: local end; url: dfn-local-end
+        text: remote end steps; url: dfn-remote-end-steps
+        text: unknown error; url: dfn-unknown-error
+        text: unsupported operation; url: dfn-unsupported-operation
+        text: session; url: dfn-session
+        text: success; url: dfn-success
+
+spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
+    type: dfn
+        text: source snapshot params; url: browsing-the-web.html#source-snapshot-params
+        text: snapshotting source snapshot params; url: browsing-the-web.html#snapshotting-source-snapshot-params
+        text: create navigation params by fetching; url: browsing-the-web.html#create-navigation-params-by-fetching
+        text: set up a window environment settings object; url: nav-history-apis.html#set-up-a-window-environment-settings-object
+        text: environment
+
+spec: storage-access; urlPrefix: https://privacycg.github.io/storage-access/
+    type: dfn
+        for: environment
+            text: has storage access; url: #environment-has-storage-access
+</pre>
+
 <pre class=biblio>
 {
     "STORAGE-ACCESS": {
@@ -44,19 +87,83 @@ This specification extends the client-side storage available beyond cookies.
 
 <h2 id="extending-saa-to-non-cookie-storage">Extending SAA to non-cookie storage</h2>
 
-TBD
+This specification defines a method to request access to [=unpartitioned data=] beyond just cookies ({{Document/requestStorageAccess(types)}}), and a method to check if cookie access has specifically been granted ({{Document/hasUnpartitionedCookieAccess()}}).
 
-<h3 id="the-document-object">Changes to {{Document}}</h3>
+<div class=example>
 
-TBD
+Alex visits `https://social.example/`. The page sets a some local storage. This local storage has been set in a [=first-party-site context=].
+
+Later on, Alex visits `https://video.example/`, which has an <{iframe}> on it which loads `https://social.example/heart-button`. In this case, the `social.example` {{Document}} |doc| is in a [=third party context=], and the local storage set previously might or might not be visible depending on User Agent storage access policies.
+
+Script in the <{iframe}> can call |doc|`.`{{Document/requestStorageAccess(types)}} to request access.
+
+```
+let handle = await document.requestStorageAccess({localStorage: true});
+handle.localStorage.setItem("userid", "1234");
+```
+
+</div>
+
+<dfn>Unpartitioned data</dfn> is client-side storage that would be available to a [=site=] were it loaded in a [=first-party-site context=].
+
+A {{Document}} is in a <dfn>first-party-site context</dfn> if it is the [=active document=] of a [=top-level browsing context=]. Otherwise, it is in a [=first-party-site context=] if it is an [=active document=] and the [=environment settings object/origin=] and [=top-level origin=] of its [=relevant settings object=] are [=same site=] with one another.
+
+A {{Document}} is in a <dfn>third party context</dfn> if it is not in a [=first-party-site context=].
+
+<h3 id="document-changes">Changes to {{Document}}</h3>
+
+<pre class="idl">
+dictionary StorageAccessTypes {
+  boolean all = false;
+  boolean cookies = false;
+};
+
+interface StorageAccessHandle {
+};
+
+partial interface Document {
+  Promise&lt;boolean> hasUnpartitionedCookieAccess();
+  Promise&lt;StorageAccessHandle> requestStorageAccess(StorageAccessTypes types);
+};
+</pre>
+
+When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>hasUnpartitionedCookieAccess()</code></dfn> method must run these steps:
+
+1. Invoke {{Document/hasStorageAccess()}}
+
+When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>requestStorageAccess(types)</code></dfn> method must run these steps:
+
+1. Let |p| be [=a new promise=].
+1. If |types|'s member |all| is `false` and |types|'s member |cookies| is `false`, then [=/reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
+1. Let |requestUnpartitionedCookieAccess| be true if |types|'s member |all| or |types|'s member |cookies| is `true` and `false` otherwise.
+1. [=React=] |p| to the invocation of {{Document/requestStorageAccess()}} given |requestUnpartitionedCookieAccess| and invoke the following steps if the promise is fufilled (if the promise is rejected then apply that same rejection to |p|):
+    1. Let |handle| be a new object of type {{StorageAccessHandle}} with |types|.
+    1. [=/Resolve=] |p| with |handle|.
+1. Return |p|.
+
+<h3 id="has-storage-access-changes">Changes to {{Document/hasStorageAccess()}}</h3>
+
+Now that {{Document/requestStorageAccess(types)}} can be used to request [=unpartitioned data=] with or without specifically requesting cookies, it must be made clear that {{Document/hasStorageAccess()}} only returns true if [=first-party-site context=] cookies are accessable to the current document.
+As a function name, {{Document/hasUnpartitionedCookieAccess()}} more clearly communicates this.
+For now {{Document/hasStorageAccess()}} is not considered deprecated, but that may be worth taking up in future.
+
+<h3 id="request-storage-access-changes">Changes to {{Document/requestStorageAccess()}}</h3>
+
+Modify {{Document/requestStorageAccess()}} to take a `boolean` |requestUnpartitionedCookieAccess| as a non-web-exposed argument which defaults to true.
+
+Modify {{Document/requestStorageAccess()}} at step 14.1.1.1.1 to read:
+
+1. If |requestUnpartitionedCookieAccess| is `true`, then set <var ignore='monkeypatch'>global</var>'s [=environment/has storage access=] to true.
+
+Modify {{Document/requestStorageAccess()}} at step 14.3 to read:
+
+3. If |explicitSetting| is "`disallow`" and |requestUnpartitionedCookieAccess| is `true`:
+
+Modify {{Document/requestStorageAccess()}} at step 14.5 to read:
+
+5. [=Assert=]: |explicitSetting| is "`none`" or |requestUnpartitionedCookieAccess| is `false`.
 
 <h3 id="storage">Changes to various client-side storage mechanisms</h3>
-
-TBD
-
-<h4 id="cookies">Cookies</h4>
-
-TBD
 
 <h4 id="dom-storage">DOM Storage</h4>
 

--- a/spec.bs
+++ b/spec.bs
@@ -112,13 +112,12 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
     1. [=/Reject=] |p| with an "{{InvalidStateError}}" {{DOMException}}.
     1. Return |p|.
 1. Let |requestUnpartitionedCookieAccess| be `true` if |types|.{{StorageAccessTypes/all}} is `true` or |types|.{{StorageAccessTypes/cookies}} is `true`, and `false` otherwise.
-1. Run the following steps [=in parallel=]:
-    1. Let |accessPromise| be the result of running [=request storage access=] with |doc| with |requestUnpartitionedCookieAccess|.
-    1. If |accessPromise| [=/rejects=] with `reason` |r|:
-        1. [=/Reject=] |p| with |r|.
-    1. Else:
-        1. Let |handle| be a new object of type {{StorageAccessHandle}} with |types|.
-        1. [=/Resolve=] |p| with |handle|.
+1. Let |accessPromise| be the result of running [=request storage access=] with |doc| with |requestUnpartitionedCookieAccess|.
+1. If |accessPromise| [=/rejects=] with `reason` |r|:
+    1. [=/Reject=] |p| with |r|.
+1. Else:
+    1. Let |handle| be a new object of type {{StorageAccessHandle}} with |types|.
+    1. [=/Resolve=] |p| with |handle|.
 1. Return |p|.
 
 

--- a/spec.bs
+++ b/spec.bs
@@ -127,7 +127,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 Redefine {{Document/requestStorageAccess()}} to:
 1. Return the result of running [=request storage access=] with |doc| and |requestUnpartitionedCookieAccess| being `true`.
 
-Redefine the steps of {{Document/requestStorageAccess()}} to instead be the steps of <dfn export>request storage access</dfn> which takes a `boolean` argument |requestUnpartitionedCookieAccess|.
+Modify {{Document/requestStorageAccess()}} to instead be the algorithm <dfn export>request storage access</dfn> which takes a {{Document}} |doc| and a `boolean` argument |requestUnpartitionedCookieAccess|.
 
 Modify {{Document/requestStorageAccess()}} at step 14.1.1.1.1 to read:
 


### PR DESCRIPTION
Let's support our first options: all and cookies!

This requires defining the basic functions and modifications to allow storage access to be requested without cookies in future.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/privacycg/saa-non-cookie-storage/pull/17.html" title="Last updated on Mar 18, 2024, 1:09 PM UTC (c7cccac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/saa-non-cookie-storage/17/8ec6a61...c7cccac.html" title="Last updated on Mar 18, 2024, 1:09 PM UTC (c7cccac)">Diff</a>