### PR TITLE
Fix missing SharedWorker matching criteria

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/universal:2",
+    "features": {
+        "ghcr.io/devcontainers-contrib/features/bikeshed:2": {}
+    }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,5 +2,12 @@
     "image": "mcr.microsoft.com/devcontainers/universal:2",
     "features": {
         "ghcr.io/devcontainers-contrib/features/bikeshed:2": {}
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "GitHub.vscode-github-actions"
+            ]
+        }
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "postCreateCommand": "sudo -H pip3 install bikeshed"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,0 @@
-{
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
-  "postCreateCommand": "sudo -H pip3 install bikeshed"
-}

--- a/spec.bs
+++ b/spec.bs
@@ -31,6 +31,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/
             text: new broadcastchannel; url: #dom-broadcastchannel
             text: shared workers; url: #shared-workers-and-the-sharedworker-interface
             text: new sharedworker; url: #dom-sharedworker
+            text: processing model; url: #worker-processing-model
 spec: storage-access; urlPrefix: https://privacycg.github.io/storage-access/
     type: dfn
         for: environment
@@ -321,11 +322,11 @@ Modify [=new SharedWorker=] to add a new step below step 1 as follows:
 
 Modify [=new SharedWorker=] to add a new matching criteria in step 10.2.2 as follows:
 
-* |scope|'s |sameSiteCookies| equals |options|.{{SharedWorkerOptions/sameSiteCookies}}.
+* <var ignore='monkeypatch'>scope</var>'s |sameSiteCookies| equals |options|.{{SharedWorkerOptions/sameSiteCookies}}.
 
 Modify [=Processing Model=] to add a new step below step 10.4 as follows:
 
-5. Set |worker global scope|'s |sameSiteCookies| to |options|.{{SharedWorkerOptions/sameSiteCookies}}.
+5. Set <var ignore='monkeypatch'>worker global scope</var>'s |sameSiteCookies| to |options|.{{SharedWorkerOptions/sameSiteCookies}}.
 
 
 Note:

--- a/spec.bs
+++ b/spec.bs
@@ -328,7 +328,6 @@ Modify [=Processing Model=] to add a new step below step 10.4 as follows:
 
 5. Set <var ignore='monkeypatch'>worker global scope</var>'s |sameSiteCookies| to |options|.{{SharedWorkerOptions/sameSiteCookies}}.
 
-
 Note:
 The {{SameSiteCookiesType}} is used to influence which cookies are sent or read during [=fetch=] based on the [=SameSite=] cookie attribute.
 {{SameSiteCookiesType/all}} is only available in [=first-party-site context=] and permits [=SameSite=] "None", "Lax", and "Strict" cookies to be included (if not blocked for some other reason).

--- a/spec.bs
+++ b/spec.bs
@@ -311,7 +311,7 @@ dictionary SharedWorkerOptions : WorkerOptions {
 
 The default {{SharedWorkerOptions/sameSiteCookies}} is {{SameSiteCookiesType/all}} in [=first-party-site context=] and {{SameSiteCookiesType/none}} otherwise.
 
-Modify {{SharedWorkerGlobalScope}} to have an associated {{SameSiteCookiesType}} |sameSiteCookies|.
+Modify {{SharedWorkerGlobalScope}} to have an associated {{SameSiteCookiesType}} <dfn export for=SharedWorkerGlobalScope>sameSiteCookies</dfn>.
 
 Modify [=new SharedWorker=] to accept {{SharedWorkerOptions}} instead of {{WorkerOptions}}.
 

--- a/spec.bs
+++ b/spec.bs
@@ -204,7 +204,7 @@ Modify {{Document/requestStorageAccess()}} at step 14.1.1.1.1 to read:
 
 For all of the following getters and methods, consider the following modifications:
 
-1. When attempting to [=obtain a storage key=] the returned key will use [[STORAGE-PARTITIONING#relaxing-additional-keying]] if the tuple does not simply contain an [=/origin=].
+1. When attempting to [=obtain a storage key for non-storage purposes=] the returned key will use [[STORAGE-PARTITIONING#relaxing-additional-keying]] if the tuple does not simply contain an [=/origin=].
 
 Issue(19): Clarify client-side storage mechanism changes in more detail.
 
@@ -310,12 +310,23 @@ dictionary SharedWorkerOptions : WorkerOptions {
 
 The default {{SharedWorkerOptions/sameSiteCookies}} is {{SameSiteCookiesType/all}} in [=first-party-site context=] and {{SameSiteCookiesType/none}} otherwise.
 
+Modify {{SharedWorkerGlobalScope}} to have an associated {{SameSiteCookiesType}} |sameSiteCookies|.
+
 Modify [=new SharedWorker=] to accept {{SharedWorkerOptions}} instead of {{WorkerOptions}}.
 
 Modify [=new SharedWorker=] to add a new step below step 1 as follows:
 
 2. If |options|.{{SharedWorkerOptions/sameSiteCookies}} is {{SameSiteCookiesType/all}} and {{Window}}'s [=associated document=] is not [=first-party-site context=], then:
     1. Throw an "{{InvalidStateError}}" {{DOMException}}.
+
+Modify [=new SharedWorker=] to add a new matching criteria in step 10.2.2 as follows:
+
+* |scope|'s |sameSiteCookies| equals |options|.{{SharedWorkerOptions/sameSiteCookies}}.
+
+Modify [=Processing Model=] to add a new step below step 10.4 as follows:
+
+5. Set |worker global scope|'s |sameSiteCookies| to |options|.{{SharedWorkerOptions/sameSiteCookies}}.
+
 
 Note:
 The {{SameSiteCookiesType}} is used to influence which cookies are sent or read during [=fetch=] based on the [=SameSite=] cookie attribute.


### PR DESCRIPTION
We need to store sameSiteCookies in the global scope so that we can match against it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/privacycg/saa-non-cookie-storage/pull/22.html" title="Last updated on Mar 19, 2024, 8:53 PM UTC (dfd7c2e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/saa-non-cookie-storage/22/2ac0b59...dfd7c2e.html" title="Last updated on Mar 19, 2024, 8:53 PM UTC (dfd7c2e)">Diff</a>