### PR TITLE
Set Exposed extended attribute on StorageAccessHandle

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -143,6 +143,7 @@ dictionary StorageAccessTypes {
   boolean SharedWorker = false;
 };
 
+[Exposed=Window]
 interface StorageAccessHandle {
   readonly attribute Storage sessionStorage;
   readonly attribute Storage localStorage;


### PR DESCRIPTION
as required by WebIDL


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/saa-non-cookie-storage/pull/28.html" title="Last updated on Jun 5, 2024, 6:51 AM UTC (0b561bc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/saa-non-cookie-storage/28/9380238...dontcallmedom:0b561bc.html" title="Last updated on Jun 5, 2024, 6:51 AM UTC (0b561bc)">Diff</a>