### PR TITLE
Make types argument optional

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -159,7 +159,7 @@ interface StorageAccessHandle {
 
 partial interface Document {
   Promise&lt;boolean> hasUnpartitionedCookieAccess();
-  Promise&lt;StorageAccessHandle> requestStorageAccess(StorageAccessTypes types);
+  Promise&lt;StorageAccessHandle> requestStorageAccess(optional StorageAccessTypes types = {});
 };
 </pre>
 


### PR DESCRIPTION
required by WebIDL for dictionary arguments without required fields


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/saa-non-cookie-storage/pull/29.html" title="Last updated on Jun 5, 2024, 8:11 AM UTC (893f9d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/saa-non-cookie-storage/29/9380238...dontcallmedom:893f9d7.html" title="Last updated on Jun 5, 2024, 8:11 AM UTC (893f9d7)">Diff</a>