### PR TITLE
Make `SharedWorkerOptions` definition a partial one

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -17,6 +17,7 @@ Complain About: accidental-2119 true
 
 <pre class=link-defaults>
 spec:html; type:dfn; for:site; text:same site
+spec:html; type:dictionary; text:SharedWorkerOptions
 spec:url; type:interface; text:URL
 </pre>
 
@@ -307,7 +308,7 @@ Modify [=Shared Workers=] to define the following:
 <pre class="idl">
 enum SameSiteCookiesType { "all", "none" };
 
-dictionary SharedWorkerOptions : WorkerOptions {
+partial dictionary SharedWorkerOptions {
   SameSiteCookiesType sameSiteCookies;
 };
 </pre>
@@ -315,8 +316,6 @@ dictionary SharedWorkerOptions : WorkerOptions {
 The default {{SharedWorkerOptions/sameSiteCookies}} is {{SameSiteCookiesType/all}} in [=first-party-site context=] and {{SameSiteCookiesType/none}} otherwise.
 
 Modify {{SharedWorkerGlobalScope}} to have an associated {{SameSiteCookiesType}} <dfn export for=SharedWorkerGlobalScope>sameSiteCookies</dfn>.
-
-Modify [=new SharedWorker=] to accept {{SharedWorkerOptions}} instead of {{WorkerOptions}}.
 
 Modify [=new SharedWorker=] to add a new step below step 1 as follows:
 


### PR DESCRIPTION
The HTML spec now defines a [`SharedWorkerOptions` dictionary](https://html.spec.whatwg.org/#shared-workers-and-the-sharedworker-interface), which the `SharedWorker` constructor accepts as parameter

On top of making the overall IDL invalid, Bikeshed sees two definitions for `SharedWorkerOptions` as a result, which makes it report a warning when the spec is built, and which will make the build job fail because the Makefile asks Bikeshed to die on warnings.

To remove the warning, this commit also creates a link default for Bikeshed to target the definition in the HTML spec. That line can be dropped once the update, which effectively drops the duplicated definition, has propagated to the cross-references database.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/saa-non-cookie-storage/pull/43.html" title="Last updated on Mar 10, 2026, 9:09 AM UTC (425ee90)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/saa-non-cookie-storage/43/0683ed3...tidoust:425ee90.html" title="Last updated on Mar 10, 2026, 9:09 AM UTC (425ee90)">Diff</a>